### PR TITLE
Add the ability to choose in which side counters appear

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         },
         "wordcounter.position.left": {
           "type":"array",
-          "default": ["word", "char", "line", "paragraph", "readingtime"],
+          "default": [],
           "description": "Control order on the left",
           "uniqueItems": true,
           "items": {

--- a/package.json
+++ b/package.json
@@ -41,26 +41,6 @@
           "default": null,
           "description": "Specifies languages which enable WordCounter, or null to enable for all."
         },
-        "wordcounter.count_words": {
-          "type": "boolean",
-          "default": true,
-          "description": "Control whether word counter is enabled or not."
-        },
-        "wordcounter.count_chars": {
-          "type": "boolean",
-          "default": true,
-          "description": "Control whether char counter is enabled or not."
-        },
-        "wordcounter.count_lines": {
-          "type": "boolean",
-          "default": true,
-          "description": "Control whether line counter is enabled or not."
-        },
-        "wordcounter.count_paragraphs": {
-          "type": "boolean",
-          "default": true,
-          "description": "Control whether paragraph counter is enabled or not."
-        },
         "wordcounter.simple_wordcount": {
           "type": "boolean",
           "default": true,
@@ -71,30 +51,25 @@
           "default": true,
           "description": "Control if char counting include eol chars or not."
         },
-        "wordcounter.readtime": {
-          "type": "boolean",
-          "default": true,
-          "description": "Control whether read time functionality is enabled or not."
-        },
         "wordcounter.wpm": {
           "type": "integer",
           "default": 200,
           "description": "Words per minute"
         },
-        "wordcounter.position.left": {
+        "wordcounter.side.left": {
           "type":"array",
-          "default": [],
-          "description": "Control order on the left",
+          "default": ["word", "char", "line", "paragraph", "readingtime"],
+          "description": "Control order on the left side of the status bar",
           "uniqueItems": true,
           "items": {
             "type": "string",
             "enum": [ "word", "char", "line", "paragraph", "readingtime" ]
           }
         },
-        "wordcounter.position.right": {
+        "wordcounter.side.right": {
           "type":"array",
           "default": [],
-          "description": "Control order on the right",
+          "description": "Control order on the right side of the status bar",
           "uniqueItems": true,
           "items": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,26 @@
           "default": 200,
           "description": "Words per minute"
         },
+        "wordcounter.position.left": {
+          "type":"array",
+          "default": ["word", "char", "line", "paragraph", "readingtime"],
+          "description": "Control order on the left",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [ "word", "char", "line", "paragraph", "readingtime" ]
+          }
+        },
+        "wordcounter.position.right": {
+          "type":"array",
+          "default": [],
+          "description": "Control order on the right",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [ "word", "char", "line", "paragraph", "readingtime" ]
+          }
+        },
         "wordcounter.text.word": {
           "type": "string",
           "default": "Word",

--- a/src/wordCounter.ts
+++ b/src/wordCounter.ts
@@ -336,8 +336,8 @@ export class WordCounterController {
       include_eol_chars: configuration.get('include_eol_chars', true),
       readtime: configuration.get('readtime', false),
       wpm: configuration.get('wpm', 200),
-      position_left: configuration.get('position.left', ["word", "char", "line", "paragraph"]),
-      position_right: configuration.get('position.right', ["readingtime"])
+      position_left: configuration.get('position.left', ["word", "char", "line", "paragraph", "readingtime"]),
+      position_right: configuration.get('position.right', [])
     } as WordCounterConfiguration;
     const text: TextConfig = {
       word: configuration.get('text.word'),

--- a/src/wordCounter.ts
+++ b/src/wordCounter.ts
@@ -35,8 +35,8 @@ interface WordCounterConfiguration {
   simple_wordcount: boolean;
   include_eol_chars: boolean;
   wpm: number;
-  position_left: Counter[];
-  position_right: Counter[];
+  side_left: Counter[];
+  side_right: Counter[];
 }
 
 interface DisplayData {
@@ -118,7 +118,7 @@ export class WordCounter {
   }
 
   toDisplay(oIn: DisplayData, alignment: StatusBarAlignment) {
-    const order = alignment === StatusBarAlignment.Left ? this.config.position_left : this.config.position_right;
+    const order = alignment === StatusBarAlignment.Left ? this.config.side_left : this.config.side_right;
     const map = {} as Record<Counter, string>
 
     if (this.config.count_words && order.includes("word")) {
@@ -327,17 +327,22 @@ export class WordCounterController {
   reloadConfig() {
     const configuration = workspace.getConfiguration('wordcounter');
     this.languages = configuration.get('languages', []);
+
+    const side_left = configuration.get('side.left', ["word", "char", "line", "paragraph", "readingtime"]) as Counter[]
+    const side_right = configuration.get('side.right', []) as Counter[]
+    const enabling = new Set<Counter>(Array.from(side_left).concat(side_right))
+
     let config: WordCounterConfiguration = {
-      count_words: configuration.get('count_words', false),
-      count_chars: configuration.get('count_chars', false),
-      count_lines: configuration.get('count_lines', false),
-      count_paragraphs: configuration.get('count_paragraphs', false),
+      count_words: enabling.has("word"),
+      count_chars: enabling.has("char"),
+      count_lines: enabling.has("line"),
+      count_paragraphs: enabling.has("paragraph"),
+      readtime: enabling.has("readingtime"),
       simple_wordcount: configuration.get('simple_wordcount', true),
       include_eol_chars: configuration.get('include_eol_chars', true),
-      readtime: configuration.get('readtime', false),
       wpm: configuration.get('wpm', 200),
-      position_left: configuration.get('position.left', ["word", "char", "line", "paragraph", "readingtime"]),
-      position_right: configuration.get('position.right', [])
+      side_left,
+      side_right,
     } as WordCounterConfiguration;
     const text: TextConfig = {
       word: configuration.get('text.word'),


### PR DESCRIPTION
I've added two new configurations
```
wordcounter.position.left
wordcounter.position.right
```
With theses configuration, you can decide on which side counters appear.

Example
```json
{
  "wordcounter.position.left": [ "word", "char", "line", "paragraph" ],
  "wordcounter.position.right": [ "readingtime" ]
}
```

Maybe this evolution need more discussion but we can improve this with the possibility to choose the order and maybe enable/disable counters.

<img width="949" alt="Capture d’écran 2020-06-06 à 13 02 15" src="https://user-images.githubusercontent.com/1800468/83942664-fb1c8d80-a7f5-11ea-80bd-43fe5aed82c7.png">